### PR TITLE
:bug: Fix error on `release` command #7

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -9,6 +9,7 @@
     "ansi-colors": "https://esm.sh/ansi-colors@4.1.3",
     "chai": "https://esm.sh/chai@4.3.10?keep-names?deno-std=0.205.0?target=deno?bundle",
     "cliffy/": "https://deno.land/x/cliffy@v1.0.0-rc.3/",
+    "emoji": "https://deno.land/x/emoji@0.3.0/mod.ts",
     "express": "https://deno.land/x/express_deno@v1.0.4/mod.ts",
     "express-handlebars": "https://esm.sh/express-handlebars@7.1.2?keep-names?deno-std=0.205.0?target=deno?bundle",
     "faker": "https://esm.sh/@faker-js/faker@8.2.0?keep-names?deno-std=0.205.0?target=deno?bundle",

--- a/utilities/git.test.ts
+++ b/utilities/git.test.ts
@@ -58,10 +58,11 @@ describe("function getCommitLabel", () => {
       ":sparkles: Message",
       ":tada: (scope) Message",
       ":construction_worker: (scope) Message (#1)",
+      "✨ Message",
     ];
     const groups = commits.map(getCommitLabel);
 
-    expect(groups).to.eql(["Added", "Added", "Added"]);
+    expect(groups).to.eql(["Added", "Added", "Added", "Added"]);
   });
 
   it("should return `Changed` if the commit subject includes an emoji belonging to that group", () => {
@@ -69,10 +70,11 @@ describe("function getCommitLabel", () => {
       ":art: Message",
       ":bento: (scope) Message",
       ":building_construction: (scope) Message (#1)",
+      "🍱 (scope) Message",
     ];
     const groups = commits.map(getCommitLabel);
 
-    expect(groups).to.eql(["Changed", "Changed", "Changed"]);
+    expect(groups).to.eql(["Changed", "Changed", "Changed", "Changed"]);
   });
 
   it("should return `Breaking Changes` if the commit subject includes an emoji belonging to that group", () => {

--- a/utilities/git.test.ts
+++ b/utilities/git.test.ts
@@ -5,6 +5,7 @@ import {
   getGitLogOutput,
 } from "@utilities/git.seeds.ts";
 import {
+  CommitSchema,
   compareCommitsByTimestamp,
   extractVersionFromCommit,
   getCommitLabel,
@@ -58,11 +59,10 @@ describe("function getCommitLabel", () => {
       ":sparkles: Message",
       ":tada: (scope) Message",
       ":construction_worker: (scope) Message (#1)",
-      "✨ Message",
     ];
     const groups = commits.map(getCommitLabel);
 
-    expect(groups).to.eql(["Added", "Added", "Added", "Added"]);
+    expect(groups).to.eql(["Added", "Added", "Added"]);
   });
 
   it("should return `Changed` if the commit subject includes an emoji belonging to that group", () => {
@@ -70,11 +70,10 @@ describe("function getCommitLabel", () => {
       ":art: Message",
       ":bento: (scope) Message",
       ":building_construction: (scope) Message (#1)",
-      "🍱 (scope) Message",
     ];
     const groups = commits.map(getCommitLabel);
 
-    expect(groups).to.eql(["Changed", "Changed", "Changed", "Changed"]);
+    expect(groups).to.eql(["Changed", "Changed", "Changed"]);
   });
 
   it("should return `Breaking Changes` if the commit subject includes an emoji belonging to that group", () => {
@@ -204,6 +203,27 @@ describe("function getReleaseObject", () => {
 
   it("should push each commit into its corresponding commit group", () => {
     expect(withFixes.changes.Fixed.commits.length).to.equal(1);
+  });
+});
+
+describe("object CommitSchema", () => {
+  const rawCommit = {
+    "hash": "46f84dae51dc3e59c431cb26f67fdb12aea08ce7",
+    "id": "46f84da",
+    "timestamp": "1699117871",
+    "author": { "name": "Victoria Rodriguez", "email": "vrodriguezfe@icloud.com" },
+    "subject": "✨ Implement setup server (#5) (#6)",
+    "body": "",
+    "ref": "",
+  };
+  const commit = CommitSchema.parse(rawCommit);
+
+  it("should correctly parse a date in the timestamp field", () => {
+    expect(commit.timestamp).to.be.instanceof(Date);
+  });
+
+  it("should correctly convert emojis to codes in its subject field", () => {
+    expect(commit.subject).to.equal(":sparkles: Implement setup server (#5) (#6)");
   });
 });
 

--- a/utilities/git.ts
+++ b/utilities/git.ts
@@ -17,7 +17,7 @@ const commitFormat = {
   ref: "%D",
 };
 
-const CommitSchema = z
+export const CommitSchema = z
   .object({
     /**
      * The commit hash.


### PR DESCRIPTION
The commit parser was updated to convert literal emojis to its emoji code before any other manipulation.

Fixes #7 

## ✅ Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All the changes made comply with the defined acceptance criteria
